### PR TITLE
Fixed "Our Events" acting as a link

### DIFF
--- a/components/magicui/animated-shiny-text.tsx
+++ b/components/magicui/animated-shiny-text.tsx
@@ -28,7 +28,7 @@ const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({ children, className, sh
         className,
       )}
       href={link}
-      target='_blank'
+      // target='_blank'
     >
       {children}
     </a>

--- a/components/magicui/animated-shiny-text.tsx
+++ b/components/magicui/animated-shiny-text.tsx
@@ -28,7 +28,6 @@ const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({ children, className, sh
         className,
       )}
       href={link}
-      // target='_blank'
     >
       {children}
     </a>


### PR DESCRIPTION
Fixed the "Our Events" page heading acting as a link opening the events section in the new tab. 
The new behavior is set to do nothing when clicked on the page heading.